### PR TITLE
checkPoint-1 / コンポーネントの整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@
   * 横19タイル、縦10タイルのボードサイズにしましょう。
 * startGameメソッドを追加して、start ボタンのclickイベントに紐付けよう。
 * startGameの実装：データ型をリセットしましょう。
-* <tr><td>タグを使用して19x10のボードを表示しよう。[ヒント] 描画のコードはデータ設計にもよりますが、タイルが二次元配列の場合、double v-for文で`<Tile>`を回す感じになります。
-  * _ヒント:_ v-for文で、要素だけではなく、indexも取得したかったらこういうシンタックスです `v-for="(row, rowIndex) in tiles"` ((v-for)[https://vuejs.org/v2/guide/list.html])
-* 一つの`<td>をTileとしてコンポーネント化しよう。
+* `<tr><td></td></tr>`タグを使用して19x10のボードを表示しよう。
+  * _ヒント_ 描画のコードはデータ設計にもよりますが、タイルが二次元配列の場合、double v-for文で`<Tile>`を回す感じになります。
+  * _ヒント:_ v-for文で、要素だけではなく、indexも取得したかったらこういうシンタックスです `v-for="(row, rowIndex) in tiles"`
+* 一つの`<td>`をTileとしてコンポーネント化しよう。
+
 
 [Checkpoint1完成画面（スタートボタンを押した後）](https://i.imgur.com/dZhUUoV.png)
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,24 +6,24 @@
       v-for="(row, rowIndex) in tiles"
       v-bind:key="rowIndex"
       >
-        <Tile
+        <TheTile
           v-for="(tile, columnIndex) in row"
-          v-bind:key="columnIndex"
-          v-bind:data="tile"
+          :key="columnIndex"
+          :data="tile"
         >
-        </Tile>
+        </TheTile>
       </tr>
     </table>
   </div>
 </template>
 
 <script>
-import Tile from './components/Tile';
+import TheTile from './components/Tile';
 
 export default {
   name: 'App',
   components: {
-    Tile,
+    TheTile,
   },
   data: () => {
     return {

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,7 @@
 
 <script>
 import Tile from './components/Tile';
+
 export default {
   name: 'App',
   components: {
@@ -33,8 +34,20 @@ export default {
   },
   methods: {
     startGame: function() {
-
-    };
+      for (let rowIndex = 0; rowIndex < this.rows; rowIndex++) {
+        let row = [];
+        for (let columnIndex = 0; columnIndex < this.columns; columnIndex++) {
+          let tile = {
+            row: rowIndex,
+            column: columnIndex,
+            mined: Math.random() * 6 > 5,
+            class: 'unopened',
+          };
+          row.push(tile);
+        }
+        this.tiles.push(row);
+      }
+    },
   }
 };
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,33 +1,40 @@
 <template>
   <div id="app">
-    <button>Start Game</button>
+    <button v-on:click="startGame">Start Game</button>
     <table class="minesweeper">
-      <tr>
-        <td class="unopened"></td>
-        <td class="unopened"></td>
-        <td class="unopened"></td>
-        <td class="unopened"></td>
-        <td class="unopened"></td>
-      </tr>
-      <tr>
-        <td class="unopened"></td>
-        <td class="unopened"></td>
-        <td class="unopened"></td>
-        <td class="unopened"></td>
-        <td class="unopened"></td>
+      <tr
+      v-for="(row, rowIndex) in tiles"
+      v-bind:key="rowIndex"
+      >
+        <Tile
+          v-for="(tile, columnIndex) in row"
+          v-bind:key="columnIndex"
+          v-bind:data="tile"
+        >
+        </Tile>
       </tr>
     </table>
   </div>
 </template>
 
 <script>
+import Tile from './components/Tile';
 export default {
   name: 'App',
+  components: {
+    Tile,
+  },
   data: () => {
-    return {};
+    return {
+      rows: 10,
+      columns: 19,
+      tiles: [],
+    };
   },
   methods: {
+    startGame: function() {
 
+    };
   }
 };
 </script>
@@ -57,53 +64,4 @@ table.minesweeper td {
   background-size: cover;
 }
 
-td.unopened {
-  background: url('./assets/unopened.svg');
-  cursor: pointer;
-}
-
-td.opened {
-  background: url('./assets/opened.svg');
-}
-
-td.flagged {
-  background: url('./assets/flag.svg');
-  cursor: pointer;
-}
-
-td.mine {
-  background: url('./assets/mine.png');
-}
-
-td.mine-neighbor-1 {
-  background: url('./assets/1.svg');
-}
-
-td.mine-neighbor-2 {
-  background: url('./assets/2.svg');
-}
-
-td.mine-neighbor-3 {
-  background: url('./assets/3.svg');
-}
-
-td.mine-neighbor-4 {
-  background: url('./assets/4.svg');
-}
-
-td.mine-neighbor-5 {
-  background: url('./assets/5.svg');
-}
-
-td.mine-neighbor-6 {
-  background: url('./assets/6.svg');
-}
-
-td.mine-neighbor-7 {
-  background: url('./assets/7.svg');
-}
-
-td.mine-neighbor-8 {
-  background: url('./assets/8.svg');
-}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -34,6 +34,7 @@ export default {
   },
   methods: {
     startGame: function() {
+      this.titles = [];
       for (let rowIndex = 0; rowIndex < this.rows; rowIndex++) {
         let row = [];
         for (let columnIndex = 0; columnIndex < this.columns; columnIndex++) {

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -1,0 +1,67 @@
+<template>
+  <td
+    v-bind:class="data.class"
+    v-on:click="$emit('leftClick', data)"
+    v-on:contextmenu.prevent="$emit('rightClick', data)"
+  >
+  </td>
+</template>
+
+<script>
+export default {
+  name: 'Tile',
+  props: ['data'],
+};
+</script>
+
+<style>
+td.unopened {
+  background: url('../assets/unopened.svg');
+  cursor: pointer;
+}
+
+td.opened {
+  background: url('../assets/opened.svg');
+}
+
+td.flagged {
+  background: url('../assets/flag.svg');
+  cursor: pointer;
+}
+
+td.mine {
+  background: url('../assets/mine.png');
+}
+
+td.mine-neighbor-1 {
+  background: url('../assets/1.svg');
+}
+
+td.mine-neighbor-2 {
+  background: url('../assets/2.svg');
+}
+
+td.mine-neighbor-3 {
+  background: url('../assets/3.svg');
+}
+
+td.mine-neighbor-4 {
+  background: url('../assets/4.svg');
+}
+
+td.mine-neighbor-5 {
+  background: url('../assets/5.svg');
+}
+
+td.mine-neighbor-6 {
+  background: url('../assets/6.svg');
+}
+
+td.mine-neighbor-7 {
+  background: url('../assets/7.svg');
+}
+
+td.mine-neighbor-8 {
+  background: url('../assets/8.svg');
+}
+</style>

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -5,7 +5,7 @@
 
 <script>
 export default {
-  name: 'Tile',
+  name: 'TheTile',
   props: ['data'],
 };
 </script>

--- a/src/components/Tile.vue
+++ b/src/components/Tile.vue
@@ -1,9 +1,5 @@
 <template>
-  <td
-    v-bind:class="data.class"
-    v-on:click="$emit('leftClick', data)"
-    v-on:contextmenu.prevent="$emit('rightClick', data)"
-  >
+  <td v-bind:class="data.class">
   </td>
 </template>
 


### PR DESCRIPTION
# 実装

- [x] データ型を設計して、コンポーネントのdata関数からデータを戻す。
  * 横19タイル、縦10タイルのボードサイズ。
- [x] startGameメソッドを追加して、start ボタンのclickイベントに紐付け。
- [x] startGameの実装：データ型をリセット。
- [x] `<tr><td></td></tr>`タグを使用して19x10のボードを表示。
- [x]  一つの`<td>`をTileとしてコンポーネント化。

# 質問
メンターさんのPRを拝見しました。
App.vue  の　　L37に
```this.tiles = [];```
とあるのですが、これはなくても良いのではないでしょうか？
最終的に
```this.tiles.push(row);```
でdataのtilesを直接変更するからいらないと思ったのですが。。。